### PR TITLE
(UPDATE) Finish multiple size selection error handling and functionality

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -78,3 +78,10 @@ export const clearSizeArray = obj => {
         payload: obj
     }
 }
+
+export const addSingleMeasure = obj => {
+    return {
+        type: "ADD_SINGLE_MEASURE",
+        payload: obj
+    }
+}

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -79,9 +79,23 @@ export const clearSizeArray = obj => {
     }
 }
 
+export const clearSingleMeasureArray = obj => {
+    return {
+        type: "CLEAR_SINGLE_MEASURE",
+        payload: obj
+    }
+}
+
 export const addSingleMeasure = obj => {
     return {
         type: "ADD_SINGLE_MEASURE",
+        payload: obj
+    }
+}
+
+export const setSecondToSize = obj => {
+    return {
+        type: "SET_SECOND",
         payload: obj
     }
 }

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -38,7 +38,7 @@
 }
 
 .padRight {
-    padding-right: 98px; 
+    padding-right: 103px; 
     display: inline-block;
 }
 

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -91,16 +91,18 @@ const CardList = (props) => {
     // hasContent: for initial filtering of checked cards
 
     const fields = props.fields.map((field) => {
-
+        newKey += 1
         //create an object and add it to store
         const storedValue = {
+            id: newKey,
             sesarTitle: "",
             oldValue: props.fieldVal[field],
             value: props.fieldVal[field],
             // this used to be id 
             header: field,
             isDate: false,
-            isMeasurement: false
+            isMeasurement: false,
+            isGreen: props.fieldVal[field] !== ""
         }
 
         // after object is created, append it to the object array & add one to the ID
@@ -108,7 +110,7 @@ const CardList = (props) => {
         useOnce.push("")
         outerArr.push(sizeArray)
         singleMeasure.push(singleMeasureObj)
-        newKey += 1
+
 
         // create the FieldCard that you see in the UI
         return (
@@ -145,6 +147,7 @@ const CardList = (props) => {
     const checkStore = () => {
         console.log(props.sizeOuter)
         console.log(props.singleMeasure)
+        console.log(props.ent)
     }
 
     // This helper function fills the multiValueArray where each index represents the "field_name", "description", or "sample_comment" selections
@@ -175,14 +178,16 @@ const CardList = (props) => {
         let options = ["field_name", "description", "sample_comment"]
         let multiValueArr = [[], [], []]
         let mapPreviewArr = []
-        let sizeSelection = ["", ""]
+        let sizeSelection = ["", "", "", ""]
         mapPreviewArr.push("-----MAP PREVIEW-----")
-        sizeSelection[0] = "-----SIZE SELECTION PREVIEW-----"
+        sizeSelection[0] = "-----SIZE SELECTION PAIRS-----"
+        sizeSelection[2] = "-----SIZE SELECTION SINGLES-----"
+
 
         /////////////////////////////////////////////////////////
         /////////// Display Preview of Multi-Value Selections
         for (let i = 0; i < props.ent.length; i++) {
-            if (props.ent[i].sesarTitle !== "") {
+            if (props.ent[i].sesarTitle !== "" && props.ent[i].sesarTitle !== "size") {
                 mapPreviewArr.push(String(props.ent[i].sesarTitle + ": " + props.ent[i].header))
             }
             multiValueArrHelper(options, i, multiValueArr)
@@ -190,6 +195,7 @@ const CardList = (props) => {
         for (let i = 0; i < 3; i++) {
             multiValueArr[i] = multiValueArr[i].join(";")
         }
+
 
         appendTitleToFront(multiValueArr, options)
 
@@ -207,14 +213,22 @@ const CardList = (props) => {
 
         //////////////////////////////////////
         // Display Size Selection Preview
-        if (props.sizeArray[2].pairHeader !== "")
-            sizeSelection[1] = "[" + props.sizeArray[2].pairHeader + "]"
-        else if (props.sizeArray[2].pairHeader === "" && (props.sizeArray[0].pairHeader === "" || props.sizeArray[1].pairHeader === "")) {
-            alert("No size selection has been made...")
-            return
+        for (let i = 0; i < props.ent.length; i++) {
+            if (props.outerArr[i][0].pairHeader !== "") {
+                if (sizeSelection[1] !== "")
+                    sizeSelection[1] = sizeSelection[1] + "\n" + (props.outerArr[i][0].pairHeader + " : " + props.outerArr[i][1].pairHeader)
+                else
+                    sizeSelection[1] = sizeSelection[1] + (props.outerArr[i][0].pairHeader + " : " + props.outerArr[i][1].pairHeader)
+            }
         }
-        else
-            sizeSelection[1] = "[" + props.sizeArray[0].pairHeader + ", " + props.sizeArray[1].pairHeader + "]"
+        for (let i = 0; i < props.ent.length; i++) {
+            if (props.singleMeasure[i].pairHeader !== "") {
+                if (sizeSelection[3] !== "")
+                    sizeSelection[3] = sizeSelection[3] + "\n" + (props.singleMeasure[i].pairHeader)
+                else
+                    sizeSelection[3] = sizeSelection[3] + (props.singleMeasure[i].pairHeader)
+            }
+        }
         alert(sizeSelection.join("\n"))
     }
 
@@ -287,7 +301,8 @@ const mapStateToProps = (state) => {
         ent: state.entries,
         sizeArray: state.sizeArray,
         sizeOuter: state.sizeOuterArray,
-        singleMeasure: state.singleMeasureArr
+        singleMeasure: state.singleMeasureArr,
+        outerArr: state.sizeOuterArray
     };
 };
 

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -25,7 +25,29 @@ const CardList = (props) => {
 
     const objArray = []
     const useOnce = []
+    const outerArr = []
+    const singleMeasure = []
     let newKey = -1
+    const singleMeasureObj = {
+        pairHeader: "",
+        pairValue: "",
+        currentID: -1
+    }
+
+    const sizeArray = [
+        // In the case of an ordered pair for SIZE, only the first two objects are used [0, 1, x]
+        // In the case of a single measurement for size, on the last object is used [x, x, 2]
+        {
+            pairHeader: "",
+            pairValue: "",
+            currentID: -1
+        },
+        {
+            pairHeader: "",
+            pairValue: "",
+            currentID: -1
+        }
+    ]
     const dateFormatOption = [
         { title: "Select Date Format" },
         { title: "DD/MM/YY or DD-MM-YY", value: "substring", type: "date" },
@@ -75,7 +97,8 @@ const CardList = (props) => {
             sesarTitle: "",
             oldValue: props.fieldVal[field],
             value: props.fieldVal[field],
-            id: field,
+            // this used to be id 
+            header: field,
             isDate: false,
             isMeasurement: false
         }
@@ -83,6 +106,8 @@ const CardList = (props) => {
         // after object is created, append it to the object array & add one to the ID
         objArray.push(storedValue)
         useOnce.push("")
+        outerArr.push(sizeArray)
+        singleMeasure.push(singleMeasureObj)
         newKey += 1
 
         // create the FieldCard that you see in the UI
@@ -101,9 +126,12 @@ const CardList = (props) => {
 
     // uses the action "firstState" with the argument "objArray" to create the Redux Store ***ONE TIME***
     useEffect(() => {
+
         const initObj = {
             objArr: objArray,
-            useOnce: useOnce
+            useOnce: useOnce,
+            sizeOuter: outerArr,
+            singleMeasureArr: singleMeasure
         }
         props.firstState(initObj)
     }, []);
@@ -115,8 +143,8 @@ const CardList = (props) => {
 
     // shows contents of the store if you click the "help" button in the console (FOR NOW)
     const checkStore = () => {
-        console.log(props.sizeArray)
-        console.log(props.ent)
+        console.log(props.sizeOuter)
+        console.log(props.singleMeasure)
     }
 
     // This helper function fills the multiValueArray where each index represents the "field_name", "description", or "sample_comment" selections
@@ -257,7 +285,9 @@ const CardList = (props) => {
 const mapStateToProps = (state) => {
     return {
         ent: state.entries,
-        sizeArray: state.sizeArray
+        sizeArray: state.sizeArray,
+        sizeOuter: state.sizeOuterArray,
+        singleMeasure: state.singleMeasureArr
     };
 };
 

--- a/src/components/DropDown.js
+++ b/src/components/DropDown.js
@@ -406,6 +406,8 @@ class DropDown extends React.Component {
         let num = -1
         // helper function to list "options" based on the 'type' of field (numbers or letters...) 
         let filter = (f) => {
+
+
             num += 1
             if (num === 0)
                 return <option key={f.title} value="Sesar Selection" disabled selected hidden>Sesar Selection</option>;
@@ -438,11 +440,23 @@ class DropDown extends React.Component {
         };
 
         // creates the dropdown, uses filter() to specify which items are included in dropdown
-        return (
-            <select className="ui dropdown" prompt="Please select option" onChange={this.updateValue}>
-                {this.props.list.map((field) => filter(field))}
-            </select>
-        );
+
+        if (this.props.hasInit && this.props.id > 0 && this.props.pairArr[this.props.id - 1][0].pairHeader !== "") {
+            return (
+
+                <select className="ui dropdown" prompt="Please select option" onChange={this.updateValue}>
+                    <option key={"size"} value={"size"}>size</option>
+                </select>
+            );
+        } else {
+            return (
+
+                <select className="ui dropdown" prompt="Please select option" onChange={this.updateValue}>
+                    {this.props.list.map((field) => filter(field))}
+                </select>
+            );
+        }
+
     }
 }
 
@@ -457,7 +471,9 @@ const mapStateToProps = (state) => {
         hasChosenCentury: state.centuryChosen,
         century: state.century,
         multiValues: state.multiValues,
-        sizeArray: state.sizeArray
+        sizeArray: state.sizeArray,
+        hasInit: state.hasInit,
+        pairArr: state.sizeOuterArray
     };
 };
 

--- a/src/components/FieldCard.js
+++ b/src/components/FieldCard.js
@@ -470,9 +470,9 @@ class FieldCard extends React.Component {
                         <object className="dropDownWidget" align="right">
                             <div className="mappedValue">{this.lengthCheckedValue(this.state.updatedValue)}</div>
                             {this.filterDrop()}
-                            {(this.state.sesarChosen === "size") ?
+                            {(this.state.sesarChosen === "size" || (this.props.hasInit && this.props.id > 0 && this.props.pairArr[this.props.id - 1][0].pairHeader !== "")) ?
                                 <object className="alignLeft">
-                                    <FormatDropdown id={this.props.id} refresh={this.refreshFieldCard} title={this.props.fieldTitle} mapValue={this.props.fieldValue} /> </object> : <div className="padRight"> </div>}
+                                    <FormatDropdown id={this.props.id} refresh={this.refreshFieldCard} title={this.props.fieldTitle} mapValue={this.props.fieldValue} /> </object> : <div className="padRight"></div>}
                         </object>
 
                     </div>
@@ -498,7 +498,7 @@ class FieldCard extends React.Component {
                             {this.filterDrop()}
                             {(this.props.fieldType === "numbers" && this.state.isGreen === true) ?
                                 <object className="alignLeft">
-                                    <FormatDropdown id={this.props.id} refresh={this.refreshFieldCard} title={this.props.fieldTitle} mapValue={this.props.fieldValue} /> </object> : <div className="padRight"> </div>}
+                                    <FormatDropdown id={this.props.id} refresh={this.refreshFieldCard} title={this.props.fieldTitle} mapValue={this.props.fieldValue} /> </object> : <div className="padRight"></div>}
                         </object>
 
                     </div>
@@ -515,7 +515,9 @@ const mapStateToProps = (state) => {
         ent: state.entries,
         useOnce: state.useOnce,
         dateFormat: state.chosenDateFormat,
-        hasChosen: state.hasChosenDateFormat
+        hasChosen: state.hasChosenDateFormat,
+        pairArr: state.sizeOuterArray,
+        hasInit: state.hasInit
     };
 };
 

--- a/src/components/FieldCard.js
+++ b/src/components/FieldCard.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import CheckboxExample from './CheckBox';
 import DropDown from './DropDown';
 import FormatDropdown from './FormatDropdown';
-import { removeContent } from '../actions';
+import { removeContent, clearSizeArray } from '../actions';
 
 
 class FieldCard extends React.Component {
@@ -361,11 +361,13 @@ class FieldCard extends React.Component {
 
     // onClick of the checkmark, change the color of the bar between green and white
     changeColor = () => {
+
         const obj = {
             oldValue: this.props.fieldValue,
             value: this.props.fieldValue,
             header: this.props.fieldTitle,
-            id: this.props.id
+            id: this.props.id,
+            isGreen: !this.state.isGreen
         }
         this.props.removeContent(obj)
         this.setState({ isGreen: !this.state.isGreen })
@@ -419,37 +421,33 @@ class FieldCard extends React.Component {
         if (this.props.hiding && this.state.isGreen === false)
             return null
 
-        // a depreciated render case for field cards 
-        // else if (this.props.hiding)
-        //     return (
-        //         <div className="ui label">
-        //             <div className={this.btnClass}>
+        else if ((this.props.hasInit && this.props.id > 0 && this.props.pairArr[this.props.id - 1][0].pairHeader !== "")) {
+            return (
+                <div className="ui label">
+                    <div className="field_container1" >
+                        <object className="fieldWidgetNoCheckbox">
+                            <div className="checkBox">
+                                <div>----</div>
+                            </div>
+                            <div dir="rtl" className="fieldTitle">{this.props.fieldTitle}</div>
+                            <div className="fieldVal" >{":        " + this.lengthCheckedValue(this.props.fieldValue)}</div>
+                        </object>
+                        <object className="arrow">
+                            <i class="fa fa-angle-double-right"></i>
+                        </object>
 
-        //                 <object className="fieldWidget">
-        //                     <div className="checkBox" onClick={this.changeColor}>
-        //                         <CheckboxExample isChecked={this.state.isGreen} />
-        //                     </div>
-        //                     <div dir="rtl" className="fieldTitle">{this.props.fieldTitle}</div>
-        //                     <div className="fieldVal" >{":        " + this.lengthCheckedValue(this.props.fieldValue)}</div>
-        //                 </object>
+                        <object className="dropDownWidget" align="right">
+                            <div className="mappedValue">{this.lengthCheckedValue(this.state.updatedValue)}</div>
+                            {this.filterDrop()}
+                            {((this.state.sesarChosen === "size" || (this.props.hasInit && this.props.id > 0 && this.props.pairArr[this.props.id - 1][0].pairHeader !== ""))) ?
+                                <object className="alignLeft">
+                                    <FormatDropdown isGreen={this.state.isGreen} id={this.props.id} refresh={this.refreshFieldCard} title={this.props.fieldTitle} mapValue={this.props.fieldValue} /> </object> : <div className="padRight"></div>}
+                        </object>
 
-        //                 <object className="arrow">
-        //                     <i class="fa fa-angle-double-right"></i>
-        //                 </object>
-
-        //                 <object className="dropDownWidget" align="right">
-
-        //                     <div className="mappedValue">{this.lengthCheckedValue(this.state.updatedValue)}</div>
-
-        //                     {this.filterDrop()}
-
-        //                     {(this.state.sesarChosen === "size") ?
-        //                         <object className="alignLeft">
-        //                         <FormatDropdown id={this.props.id} refresh={this.refreshFieldCard} title={this.props.fieldTitle} mapValue={this.props.fieldValue} /> </object> : <div className="padRight"> </div>}
-        //                 </object>
-        //             </div>
-        //         </div>
-        //     )
+                    </div>
+                </div>
+            )
+        }
 
         //returns the green styled field card
         else if (this.state.isGreen) {
@@ -470,9 +468,9 @@ class FieldCard extends React.Component {
                         <object className="dropDownWidget" align="right">
                             <div className="mappedValue">{this.lengthCheckedValue(this.state.updatedValue)}</div>
                             {this.filterDrop()}
-                            {(this.state.sesarChosen === "size" || (this.props.hasInit && this.props.id > 0 && this.props.pairArr[this.props.id - 1][0].pairHeader !== "")) ?
+                            {((this.state.sesarChosen === "size" || (this.props.hasInit && this.props.id > 0 && this.props.pairArr[this.props.id - 1][0].pairHeader !== ""))) ?
                                 <object className="alignLeft">
-                                    <FormatDropdown id={this.props.id} refresh={this.refreshFieldCard} title={this.props.fieldTitle} mapValue={this.props.fieldValue} /> </object> : <div className="padRight"></div>}
+                                    <FormatDropdown isGreen={this.state.isGreen} id={this.props.id} refresh={this.refreshFieldCard} title={this.props.fieldTitle} mapValue={this.props.fieldValue} /> </object> : <div className="padRight"></div>}
                         </object>
 
                     </div>
@@ -498,7 +496,7 @@ class FieldCard extends React.Component {
                             {this.filterDrop()}
                             {(this.props.fieldType === "numbers" && this.state.isGreen === true) ?
                                 <object className="alignLeft">
-                                    <FormatDropdown id={this.props.id} refresh={this.refreshFieldCard} title={this.props.fieldTitle} mapValue={this.props.fieldValue} /> </object> : <div className="padRight"></div>}
+                                    <FormatDropdown isGreen={this.state.isGreen} id={this.props.id} refresh={this.refreshFieldCard} title={this.props.fieldTitle} mapValue={this.props.fieldValue} /> </object> : <div className="padRight"></div>}
                         </object>
 
                     </div>
@@ -521,4 +519,4 @@ const mapStateToProps = (state) => {
     };
 };
 
-export default connect(mapStateToProps, { removeContent })(FieldCard);
+export default connect(mapStateToProps, { removeContent, clearSizeArray })(FieldCard);

--- a/src/components/FormatDropdown.js
+++ b/src/components/FormatDropdown.js
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import "semantic-ui-react";
 
 // Action Creators
-import { addToSizeArray, clearSizeArray, addSingleMeasure } from "../actions/"
+import { addToSizeArray, clearSizeArray, addSingleMeasure, setSecondToSize, removeContent, clearSingleMeasureArray } from "../actions/"
 
 class FormatDropdown extends React.Component {
 
@@ -26,6 +26,69 @@ class FormatDropdown extends React.Component {
         // If "First in Pair" is selected
         if (value === "first") {
             dex = 0
+            let numbers = /^[-0-9.^$]*$/;
+
+            if (!this.props.ent[this.props.id + 1].isGreen) {
+                alert("ERROR: \"" + this.props.ent[this.props.id + 1].header + "\" : \"" + this.props.ent[this.props.id + 1].value + " is not checked to be used in the map!")
+                const obj = {
+                    id: this.props.id
+                }
+                const removeEntObj = {
+                    cardID: this.props.id,
+                    id: this.props.id,
+                    oldValue: this.props.ent[this.props.id].oldValue,
+                    header: this.props.ent[this.props.id].header,
+                    value: this.props.ent[this.props.id].value,
+                    isGreen: this.props.ent[this.props.id].isGreen
+                }
+                this.props.removeContent(removeEntObj)
+                this.props.clearSingleMeasureArray(obj)
+                this.props.refresh()
+                return
+            }
+
+            if (this.props.id === this.props.ent.lenth - 1) {
+                alert("ERROR: \"" + this.props.ent[this.props.id + 1].header + "\" : \"" + this.props.ent[this.props.id + 1].value + " is the last entry which cannot be assigned as a pair.")
+                const obj = {
+                    id: this.props.id
+                }
+                const removeEntObj = {
+                    cardID: this.props.id,
+                    id: this.props.id,
+                    oldValue: this.props.ent[this.props.id].oldValue,
+                    header: this.props.ent[this.props.id].header,
+                    value: this.props.ent[this.props.id].value,
+                    isGreen: this.props.ent[this.props.id].isGreen
+                }
+                this.props.removeContent(removeEntObj)
+                this.props.clearSingleMeasureArray(obj)
+
+                this.props.refresh()
+                return
+            }
+
+            if ((numbers.test(this.props.ent[this.props.id + 1].value) === false || numbers.test(this.props.ent[this.props.id].value) === false)) {
+                alert("ERROR: \"" + this.props.ent[this.props.id + 1].header + "\" has the content \"" + this.props.ent[this.props.id + 1].value + "\" which is not a number! \n**SOLUTION**\nYou're first in pair should be the initial metric (CM) where the next card down should be your precision metric (MM)!")
+                const obj = {
+                    id: this.props.id
+                }
+                const removeEntObj = {
+                    cardID: this.props.id,
+                    id: this.props.id,
+                    oldValue: this.props.ent[this.props.id].oldValue,
+                    header: this.props.ent[this.props.id].header,
+                    value: this.props.ent[this.props.id].value,
+                    isGreen: this.props.ent[this.props.id].isGreen
+                }
+                this.props.removeContent(removeEntObj)
+                this.props.clearSingleMeasureArray(obj)
+                this.props.refresh()
+                return
+            }
+            const obj = {
+                id: this.props.id
+            }
+            this.props.clearSingleMeasureArray(obj)
 
 
 
@@ -34,27 +97,29 @@ class FormatDropdown extends React.Component {
 
         // If "Measurment" is selected 
         else {
-            dex = 2
+            if (this.props.hasInit && this.props.id > 0 && this.props.pairArr[this.props.id][0].pairHeader !== "") {
+                const objEntArr = {
+                    cardID: this.props.id + 1,
+                    id: this.props.id + 1,
+                    oldValue: this.props.ent[this.props.id + 1].oldValue,
+                    header: this.props.ent[this.props.id + 1].header,
+                    value: this.props.ent[this.props.id + 1].value,
+                    isGreen: this.props.ent[this.props.id + 1].isGreen
+                }
+                this.props.removeContent(objEntArr)
+            }
 
-            if (((sizeArray[2].currentID !== this.props.id && sizeArray[2].currentID !== -1) && (sizeArray[0].pairHeader !== "" || sizeArray[1].pairHeader !== "")) ||
-                (sizeArray[2].pairHeader !== "" && sizeArray[2].currentID !== this.props.id) ||
-                (sizeArray[0].pairHeader !== "" && sizeArray[0].currentID !== this.props.id) || (sizeArray[1].pairHeader !== "" && sizeArray[1].currentID !== this.props.id)
-            ) {
-                alert("You have already selected a pair, you cannot also use a single measurement!")
-                this.props.refresh();
-                return
+
+            dex = 2
+            const obj = {
+                cardID: this.props.id,
+                index: 0
             }
-            if (this.props.sizeArray[0].pairHeader !== "") {
-                let obj = { id: 0 }
-                this.props.clearSizeArray(obj)
-            }
-            else if (this.props.sizeArray[1].pairHeader !== "") {
-                let obj = { id: 1 }
-                this.props.clearSizeArray(obj)
-            }
+            this.props.clearSizeArray(obj)
+
         }
         if (value === "first") {
-            const obj = {
+            const objSizeArr = {
                 header: this.props.title,
                 value: this.props.mapValue,
                 index: dex,
@@ -64,7 +129,16 @@ class FormatDropdown extends React.Component {
                 nextValue: this.props.ent[this.props.id + 1].value,
                 nextID: this.props.id + 1
             }
-            this.props.addToSizeArray(obj)
+            const objEntArr = {
+                cardID: this.props.id + 1,
+                id: this.props.id + 1,
+                oldValue: this.props.ent[this.props.id + 1].oldValue,
+                header: this.props.ent[this.props.id + 1].header,
+                value: this.props.ent[this.props.id + 1].value,
+                isGreen: this.props.ent[this.props.id + 1].isGreen
+            }
+            this.props.addToSizeArray(objSizeArr)
+            this.props.setSecondToSize(objEntArr)
         } else {
             const obj = {
                 header: this.props.title,
@@ -107,6 +181,8 @@ class FormatDropdown extends React.Component {
             );
 
         }
+
+
         else {
             return (
                 <select onChange={this.updateValue}>
@@ -132,8 +208,9 @@ const mapStateToProps = (state) => {
         hasChosen: state.hasChosenDateFormat,
         sizeArray: state.sizeArray,
         pairArr: state.sizeOuterArray,
-        hasInit: state.hasInit
+        hasInit: state.hasInit,
+        singleMeasureArr: state.singleMeasureArr
     };
 };
 
-export default connect(mapStateToProps, { addToSizeArray, clearSizeArray, addSingleMeasure })(FormatDropdown);
+export default connect(mapStateToProps, { addToSizeArray, clearSizeArray, addSingleMeasure, setSecondToSize, removeContent, clearSingleMeasureArray })(FormatDropdown);

--- a/src/components/FormatDropdown.js
+++ b/src/components/FormatDropdown.js
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import "semantic-ui-react";
 
 // Action Creators
-import { addToSizeArray, clearSizeArray } from "../actions/"
+import { addToSizeArray, clearSizeArray, addSingleMeasure } from "../actions/"
 
 class FormatDropdown extends React.Component {
 
@@ -27,50 +27,10 @@ class FormatDropdown extends React.Component {
         if (value === "first") {
             dex = 0
 
-            if ((this.props.sizeArray[2].pairHeader !== "" && (this.props.sizeArray[0].pairHeader !== "" && this.props.sizeArray[1] !== "") && this.props.sizeArray[2].currentID !== this.props.id) ||
-                ((sizeArray[0].currentID !== -1 || sizeArray[0].currentID !== this.props.id) && (sizeArray[0].pairHeader !== ""))
-            ) {
-                alert("You've already selected another size option as a single measurement! You can either have a pair, or a single measurement")
-                this.props.refresh()
-                return
-            }
-            else if (this.props.title === this.props.sizeArray[1].pairHeader && this.props.mapValue === this.props.sizeArray[1].pairValue) {
 
-                let obj = { id: 1 }
-                this.props.clearSizeArray(obj)
-            }
-            else if (this.props.title === this.props.sizeArray[2].pairHeader && this.props.mapValue === this.props.sizeArray[2].pairValue) {
-
-                let obj = { id: 2 }
-                this.props.clearSizeArray(obj)
-            }
 
         }
-        // If "Second in Pair" is selected
-        else if (value === "second") {
-            dex = 1
-            if ((this.props.sizeArray[2].pairHeader !== "" && (this.props.sizeArray[1].pairHeader !== "" && this.props.sizeArray[0] !== "") && this.props.sizeArray[2].currentID !== this.props.id) ||
-                ((sizeArray[1].currentID !== -1 || sizeArray[1].currentID !== this.props.id) && (sizeArray[1].pairHeader !== ""))
-            ) {
-                console.log("1")
-                alert("You've already selected another size option as a single measurement! You can either have a pair, or a single measurement")
-                this.props.refresh()
-                return
-            }
-            else if (this.props.title === this.props.sizeArray[0].pairHeader && this.props.mapValue === this.props.sizeArray[0].pairValue) {
 
-                let obj = { id: 0 }
-                this.props.clearSizeArray(obj)
-            }
-            else if ((this.props.title === this.props.sizeArray[2].pairHeader && this.props.mapValue === this.props.sizeArray[2].pairValue) ||
-                (this.props.title === this.props.sizeArray[1].pairHeader && this.props.mapValue === this.props.sizeArray[1].pairValue)) {
-
-                let obj = { id: 2 }
-                this.props.clearSizeArray(obj)
-            }
-            // if the fieldcard header/value === pairHeader/pairValue in sizeArray, then clearSizeArray (original choice)
-
-        }
 
         // If "Measurment" is selected 
         else {
@@ -93,19 +53,32 @@ class FormatDropdown extends React.Component {
                 this.props.clearSizeArray(obj)
             }
         }
+        if (value === "first") {
+            const obj = {
+                header: this.props.title,
+                value: this.props.mapValue,
+                index: dex,
+                cardID: this.props.id,
 
-        const obj = {
-            header: this.props.title,
-            value: this.props.mapValue,
-            index: dex,
-            cardID: this.props.id
+                nextHeader: this.props.ent[this.props.id + 1].header,
+                nextValue: this.props.ent[this.props.id + 1].value,
+                nextID: this.props.id + 1
+            }
+            this.props.addToSizeArray(obj)
+        } else {
+            const obj = {
+                header: this.props.title,
+                value: this.props.mapValue,
+                cardID: this.props.id
+            }
+            this.props.addSingleMeasure(obj)
         }
 
-        this.props.addToSizeArray(obj)
 
     }
 
     render() {
+        /*
         if (
             (((this.sizeArrayLoop() === 2 && this.props.ent[this.props.id].sesarTitle === "size" && this.props.sizeArray[1].pairHeader !== "") &&
                 (this.sizeArrayLoop() === 2 && this.props.ent[this.props.id].sesarTitle === "size" && this.props.sizeArray[0].pairHeader !== "")) ||
@@ -121,23 +94,35 @@ class FormatDropdown extends React.Component {
                 </select>
             );
         }
+        */
+
+        if (this.props.hasInit && this.props.id > 0 && this.props.pairArr[this.props.id - 1][0].pairHeader !== "") {
+            return (
+                <select onChange={this.updateValue}>
+                    <option value={"choose data format"} disabled hidden>format type</option>
+                    <option value={"first"} disabled >1st in Pair </option>
+                    <option value={"second"} disabled selected>  2nd in Pair</option>
+                    <option value={"measurement"} disabled >Measurement</option>
+                </select>
+            );
+
+        }
         else {
             return (
                 <select onChange={this.updateValue}>
                     <option value={"choose data format"} disabled selected hidden>format type</option>
                     <option value={"first"}>1st in Pair </option>
-                    <option value={"second"}>2nd in Pair</option>
                     <option value={"measurement"}>Measurement</option>
                 </select>
             );
         }
 
-
     }
 
 
-
 }
+
+
 
 const mapStateToProps = (state) => {
     return {
@@ -145,8 +130,10 @@ const mapStateToProps = (state) => {
         useOnce: state.useOnce,
         dateFormat: state.chosenDateFormat,
         hasChosen: state.hasChosenDateFormat,
-        sizeArray: state.sizeArray
+        sizeArray: state.sizeArray,
+        pairArr: state.sizeOuterArray,
+        hasInit: state.hasInit
     };
 };
 
-export default connect(mapStateToProps, { addToSizeArray, clearSizeArray })(FormatDropdown);
+export default connect(mapStateToProps, { addToSizeArray, clearSizeArray, addSingleMeasure })(FormatDropdown);

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -17,6 +17,9 @@ import update from 'react-addons-update';
 const reducer =
   (state =
     {
+      hasInit: false,
+      singleMeasureArr: [],
+      sizeOuterArray: [],
       sizeArray: [
         // In the case of an ordered pair for SIZE, only the first two objects are used [0, 1, x]
         // In the case of a single measurement for size, on the last object is used [x, x, 2]
@@ -70,7 +73,9 @@ const reducer =
           ...state,
           entries: state.entries.concat(action.payload.objArr),
           useOnce: state.useOnce.concat(action.payload.useOnce),
-          stringDateMeasure: state.stringDateMeasure.concat(action.payload.sDM)
+          sizeOuterArray: state.sizeOuterArray.concat(action.payload.sizeOuter),
+          singleMeasureArr: state.singleMeasureArr.concat(action.payload.singleMeasureArr),
+          hasInit: true
         }
 
       // DROPDOWN_UPDATE updates a specific object in the store "entries[id[" when option is clicked
@@ -193,14 +198,24 @@ const reducer =
       case "ADD_TO_SIZE_ARRAY":
         return update(state,
           {
-            sizeArray: {
-              [action.payload.index]: {
-                pairHeader: { $set: action.payload.header },
-                pairValue: { $set: action.payload.value },
-                currentID: { $set: action.payload.cardID }
+            sizeOuterArray: {
+              [action.payload.cardID]: {
+                [action.payload.index]: {
+                  pairHeader: { $set: action.payload.header },
+                  pairValue: { $set: action.payload.value },
+                  currentID: { $set: action.payload.cardID }
+                },
+                [action.payload.index + 1]: {
+                  pairHeader: { $set: action.payload.nextHeader },
+                  pairValue: { $set: action.payload.nextValue },
+                  currentID: { $set: action.payload.nextID }
+                }
+
               }
             }
           });
+
+      // add changing second entries to have payload.index + 1 contents
 
 
 
@@ -215,6 +230,21 @@ const reducer =
               }
             }
           });
+
+
+      case "ADD_SINGLE_MEASURE":
+        return update(state,
+          {
+            singleMeasureArr: {
+              [action.payload.cardID]: {
+                pairHeader: { $set: action.payload.header },
+                pairValue: { $set: action.payload.value },
+                currentID: { $set: action.payload.cardID }
+              }
+            }
+          }
+        )
+
 
       default:
         return state

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -100,7 +100,8 @@ const reducer =
               header: action.payload.header,
               // taking a look at isDate and isMeasurment later along with other intricacies of the store/dropdown dynamic
               isDate: false,
-              isMeasurement: false
+              isMeasurement: false,
+              isGreen: true
             },
             ...state.entries.slice(index + 1)
           ],
@@ -189,7 +190,8 @@ const reducer =
               header: action.payload.header,
               // taking a look at isDate and isMeasurment later along with other intricacies of the store/dropdown dynamic
               isDate: false,
-              isMeasurement: false
+              isMeasurement: false,
+              isGreen: action.payload.isGreen
             },
             ...state.entries.slice(i + 1)
           ]
@@ -222,7 +224,27 @@ const reducer =
       case "REMOVE_ITEM_SIZE_ARRAY":
         return update(state,
           {
-            sizeArray: {
+            sizeOuterArray: {
+              [action.payload.cardID]: {
+                [action.payload.index]: {
+                  pairHeader: { $set: "" },
+                  pairValue: { $set: "" },
+                  currentID: { $set: -1 }
+                },
+                [action.payload.index + 1]: {
+                  pairHeader: { $set: "" },
+                  pairValue: { $set: "" },
+                  currentID: { $set: -1 }
+                }
+
+              }
+            }
+          });
+
+      case "CLEAR_SINGLE_MEASURE":
+        return update(state,
+          {
+            singleMeasureArr: {
               [action.payload.id]: {
                 pairHeader: { $set: "" },
                 pairValue: { $set: "" },
@@ -230,7 +252,6 @@ const reducer =
               }
             }
           });
-
 
       case "ADD_SINGLE_MEASURE":
         return update(state,
@@ -240,6 +261,25 @@ const reducer =
                 pairHeader: { $set: action.payload.header },
                 pairValue: { $set: action.payload.value },
                 currentID: { $set: action.payload.cardID }
+              }
+            }
+          }
+        )
+
+      case "SET_SECOND":
+        return update(state,
+          {
+            entries: {
+              [action.payload.cardID]: {
+                id: { $set: action.payload.id },
+                sesarTitle: { $set: "size" },
+                oldValue: { $set: action.payload.oldValue },
+                value: { $set: action.payload.value },
+                header: { $set: action.payload.header },
+                // taking a look at isDate and isMeasurment later along with other intricacies of the store/dropdown dynamic
+                isDate: { $set: false },
+                isMeasurement: { $set: false },
+                isGreen: { $set: action.payload.isGreen }
               }
             }
           }


### PR DESCRIPTION
(UPDATE) No known errors with multiple size selections

- One alert to add is when a user goes to preview or map and they have chosen "size" without specifying the format of the "size" selection. 
---- The best way to handle this is to default the UI dropdown as "Measurement" so that the default is a single measurement which will never be a problem. When the user selects "Pair" then the necessary changes are made to the store. This way if they don't select a format and they go to map, they are able to do this without getting an ugly error message. 